### PR TITLE
Fix page overlay data

### DIFF
--- a/Classes/Service/OgRendererService.php
+++ b/Classes/Service/OgRendererService.php
@@ -28,6 +28,8 @@ use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * Class OgRendererService
@@ -86,25 +88,28 @@ class OgRendererService implements \TYPO3\CMS\Core\SingletonInterface
         //if there has been no return, get og properties and render output
 
         // Get title
-        if (!empty($this->cObj->data['tx_jhopengraphprotocol_ogtitle'])) {
-            $og['title'] = $this->cObj->data['tx_jhopengraphprotocol_ogtitle'];
+        if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'])) {
+            $og['title'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'];
         } else {
             $og['title'] = $GLOBALS['TSFE']->page['title'];
         }
         $og['title'] = htmlspecialchars($og['title']);
 
         // Get type
-        if (!empty($this->cObj->data['tx_jhopengraphprotocol_ogtype'])) {
-            $og['type'] = $this->cObj->data['tx_jhopengraphprotocol_ogtype'];
+        if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'])) {
+            $og['type'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'];
         } else {
             $og['type'] = $conf['type'];
         }
         $og['type'] = htmlspecialchars($og['type']);
 
+		$fileRelationPid = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ?: $GLOBALS['TSFE']->id;
+		$fileRelationTable = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ? 'pages_language_overlay' : 'pages';
+
         // Get image
         /** @var \TYPO3\CMS\Core\Resource\FileRepository $fileRepository */
         $fileRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
-        $fileObjects = $fileRepository->findByRelation('pages', 'tx_jhopengraphprotocol_ogfalimages', $GLOBALS['TSFE']->id);
+		$fileObjects = $fileRepository->findByRelation($fileRelationTable, 'tx_jhopengraphprotocol_ogfalimages', $fileRelationPid);
         if (count($fileObjects)) {
             foreach ($fileObjects as $key => $fileObject) {
                 /** @var FileReference $fileObject */
@@ -112,7 +117,7 @@ class OgRendererService implements \TYPO3\CMS\Core\SingletonInterface
             }
         } else {
             // check if an image is given in page --> media, if not use default image
-            $fileObjects = $fileRepository->findByRelation('pages', 'media', $GLOBALS['TSFE']->id);
+            $fileObjects = $fileRepository->findByRelation($fileRelationTable, 'media', $fileRelationPid);
             if (count($fileObjects)) {
                 foreach ($fileObjects as $key => $fileObject) {
                     /** @var FileReference $fileObject */
@@ -138,8 +143,8 @@ class OgRendererService implements \TYPO3\CMS\Core\SingletonInterface
         $og['site_name'] = htmlspecialchars($og['site_name']);
 
         // Get description
-        if (!empty($this->cObj->data['tx_jhopengraphprotocol_ogdescription'])) {
-            $og['description'] = $this->cObj->data['tx_jhopengraphprotocol_ogdescription'];
+        if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'])) {
+            $og['description'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'];
         } else {
             if (!empty($GLOBALS['TSFE']->page['description'])) {
                 $og['description'] = $GLOBALS['TSFE']->page['description'];

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "support": {
     "issues": "https://github.com/jonathanheilmann/ext-jh_opengraphprotocol/issues"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "replace": {
     "jh_opengraphprotocol": "self.version",
     "typo3-ter/jh-opengraphprotocol": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "support": {
     "issues": "https://github.com/jonathanheilmann/ext-jh_opengraphprotocol/issues"
   },
-  "version": "1.2.2",
+  "version": "1.2.3",
   "replace": {
     "jh_opengraphprotocol": "self.version",
     "typo3-ter/jh-opengraphprotocol": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "support": {
     "issues": "https://github.com/jonathanheilmann/ext-jh_opengraphprotocol/issues"
   },
-  "version": "1.2.5",
+  "version": "1.2.6",
   "replace": {
     "jh_opengraphprotocol": "self.version",
     "typo3-ter/jh-opengraphprotocol": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,6 @@
     "issues": "https://github.com/jonathanheilmann/ext-jh_opengraphprotocol/issues"
   },
   "version": "1.2.1",
-  "require": {
-    "typo3/cms": "~6.2,~7.6"
-  },
   "replace": {
     "jh_opengraphprotocol": "self.version",
     "typo3-ter/jh-opengraphprotocol": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "support": {
     "issues": "https://github.com/jonathanheilmann/ext-jh_opengraphprotocol/issues"
   },
-  "version": "1.2.3",
+  "version": "1.2.5",
   "replace": {
     "jh_opengraphprotocol": "self.version",
     "typo3-ter/jh-opengraphprotocol": "self.version"

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -74,7 +74,7 @@ $tempColumns = array(
         'config' => array(
             'type' => 'text',
             'size' => '30',
-            'rows' => '3'
+            'rows' => '3',
             'max' => '300',
         )
     ),

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -72,8 +72,9 @@ $tempColumns = array(
         'exclude' => 1,
         'label' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang.xml:pages.tx_jhopengraphprotocol_ogdescription',
         'config' => array(
-            'type' => 'input',
+            'type' => 'text',
             'size' => '30',
+            'rows' => '3'
             'max' => '300',
         )
     ),


### PR DESCRIPTION
This fixes the page overlay bug #23 I guess.
The changes to composer.json can be ignored. I had to make them to temporarily integrate my fork into our project.

The problem with the page overlay was, that `$this->cObj->data` only contains the information of the current database record, but without being overlayed. The `$GLOBALS['TSFE']->page` is the way to go for all fields.

Additionally fetching the file relations have to be done from `pages_language_overlay` if not in default language. Therefore I introduced two new variables for fetching file relations based on the curreent `sys_language_uid`.

This is only tested on TYPO3 7.6.9 but I think it should work on every other supported version.