### PR TITLE
Bugfix/page overlay

### DIFF
--- a/Classes/Service/OgRendererService.php
+++ b/Classes/Service/OgRendererService.php
@@ -2,34 +2,32 @@
 namespace Heilmann\JhOpengraphprotocol\Service;
 
 /***************************************************************
- *  Copyright notice
- *
- *  (c) 2014-2016 Jonathan Heilmann <mail@jonathan-heilmann.de>
- *  All rights reserved
- *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+*  Copyright notice
+*
+*  (c) 2014-2016 Jonathan Heilmann <mail@jonathan-heilmann.de>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
 
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * Class OgRendererService
@@ -38,280 +36,280 @@ use TYPO3\CMS\Frontend\Page\PageRepository;
 class OgRendererService implements \TYPO3\CMS\Core\SingletonInterface
 {
 
-	/**
-	 * content Object
-	 *
-	 * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
-	 */
-	public $cObj;
+    /**
+     * content Object
+     *
+     * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
+     */
+    public $cObj;
 
-	/**
-	 * SignalSlotDispatcher
-	 *
-	 * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
-	 * @inject
-	 */
-	protected $signalSlotDispatcher;
+    /**
+     * SignalSlotDispatcher
+     *
+     * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
+     * @inject
+     */
+    protected $signalSlotDispatcher;
 
-	/**
-	 * Main-function to render the Open Graph protocol content.
-	 *
-	 * @param	string	$content
-	 * @param	array		$conf
-	 * @return	string
-	 */
-	public function main($content, $conf)
-	{
-		$extKey = 'tx_jhopengraphprotocol';
-		$content = '';
-		$og = array();
+    /**
+     * Main-function to render the Open Graph protocol content.
+     *
+     * @param	string	$content
+     * @param	array		$conf
+     * @return	string
+     */
+    public function main($content, $conf)
+    {
+        $extKey = 'tx_jhopengraphprotocol';
+        $content = '';
+        $og = array();
 
-		if ($this->signalSlotDispatcher == null) {
-			/* @var \TYPO3\CMS\Extbase\Object\ObjectManager */
-			$objectManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-			$this->signalSlotDispatcher = $objectManager->get('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
-		}
+        if ($this->signalSlotDispatcher == null) {
+            /* @var \TYPO3\CMS\Extbase\Object\ObjectManager */
+            $objectManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
+            $this->signalSlotDispatcher = $objectManager->get('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
+        }
 
-		// 2013-04-22	kraftb@webconsulting.at
-		// Check if the tt_news "displaySingle" method has been called before
-		if (class_exists('tx_jhopengraphttnews_displaySingleHook')) {
-			$hookObject = GeneralUtility::makeInstance('tx_jhopengraphttnews_displaySingleHook');
-			if ($hookObject->singleViewDisplayed())
-				return $content;
-		}
-		if (class_exists(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class)) {
-			$hookObject = GeneralUtility::makeInstance(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class);
-			if ($hookObject->singleViewDisplayed())
-				return $content;
-		}
+        // 2013-04-22	kraftb@webconsulting.at
+        // Check if the tt_news "displaySingle" method has been called before
+        if (class_exists('tx_jhopengraphttnews_displaySingleHook')) {
+            $hookObject = GeneralUtility::makeInstance('tx_jhopengraphttnews_displaySingleHook');
+            if ($hookObject->singleViewDisplayed())
+                return $content;
+        }
+        if (class_exists(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class)) {
+            $hookObject = GeneralUtility::makeInstance(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class);
+            if ($hookObject->singleViewDisplayed())
+                return $content;
+        }
 
-		//if there has been no return, get og properties and render output
+        //if there has been no return, get og properties and render output
 
-		// Get title
-		if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'])) {
-			$og['title'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'];
-		} else {
-			$og['title'] = $GLOBALS['TSFE']->page['title'];
-		}
-		$og['title'] = htmlspecialchars($og['title']);
+        // Get title
+        if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'])) {
+            $og['title'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'];
+        } else {
+            $og['title'] = $GLOBALS['TSFE']->page['title'];
+        }
+        $og['title'] = htmlspecialchars($og['title']);
 
-		// Get type
-		if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'])) {
-			$og['type'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'];
-		} else {
-			$og['type'] = $conf['type'];
-		}
-		$og['type'] = htmlspecialchars($og['type']);
+        // Get type
+        if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'])) {
+            $og['type'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'];
+        } else {
+            $og['type'] = $conf['type'];
+        }
+        $og['type'] = htmlspecialchars($og['type']);
 
+        // Get image
 		$fileRelationPid = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ?: $GLOBALS['TSFE']->id;
 		$fileRelationTable = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ? 'pages_language_overlay' : 'pages';
 
-		// Get image
 		/** @var \TYPO3\CMS\Core\Resource\FileRepository $fileRepository */
-		$fileRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
-		$fileObjects = $fileRepository->findByRelation($fileRelationTable, 'tx_jhopengraphprotocol_ogfalimages', $fileRelationPid);
-		if (count($fileObjects)) {
-			foreach ($fileObjects as $key => $fileObject) {
-				/** @var FileReference $fileObject */
-				$og['image'][] = $fileObject;
-			}
-		} else {
-			// check if an image is given in page --> media, if not use default image
-			$fileObjects = $fileRepository->findByRelation($fileRelationTable, 'media', $fileRelationPid);
-			if (count($fileObjects)) {
-				foreach ($fileObjects as $key => $fileObject) {
-					/** @var FileReference $fileObject */
-					$og['image'][] = $fileObject;
-				}
-			} else {
-				$imageFileName = $GLOBALS['TSFE']->tmpl->getFileName($conf['image']);
-				if (!empty($imageFileName)) {
-					$og['image'][] = $imageFileName;
-				}
-			}
-		}
+        $fileRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
+        $fileObjects = $fileRepository->findByRelation($fileRelationTable, 'tx_jhopengraphprotocol_ogfalimages', $fileRelationPid);
+        if (count($fileObjects)) {
+            foreach ($fileObjects as $key => $fileObject) {
+                /** @var FileReference $fileObject */
+                $og['image'][] = $fileObject;
+            }
+        } else {
+            // check if an image is given in page --> media, if not use default image
+            $fileObjects = $fileRepository->findByRelation($fileRelationTable, 'media', $fileRelationPid);
+            if (count($fileObjects)) {
+                foreach ($fileObjects as $key => $fileObject) {
+                    /** @var FileReference $fileObject */
+                    $og['image'][] = $fileObject;
+                }
+            } else {
+                $imageFileName = $GLOBALS['TSFE']->tmpl->getFileName($conf['image']);
+                if (!empty($imageFileName)) {
+                    $og['image'][] = $imageFileName;
+                }
+            }
+        }
 
-		// Get url
-		$og['url'] = htmlentities(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
+        // Get url
+        $og['url'] = htmlentities(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
 
-		// Get site_name
-		if (!empty($conf['sitename'])) {
-			$og['site_name'] = $conf['sitename'];
-		} else {
-			$og['site_name'] = $GLOBALS['TSFE']->tmpl->setup['sitetitle'];
-		}
-		$og['site_name'] = htmlspecialchars($og['site_name']);
+        // Get site_name
+        if (!empty($conf['sitename'])) {
+            $og['site_name'] = $conf['sitename'];
+        } else {
+            $og['site_name'] = $GLOBALS['TSFE']->tmpl->setup['sitetitle'];
+        }
+        $og['site_name'] = htmlspecialchars($og['site_name']);
 
-		// Get description
-		if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'])) {
-			$og['description'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'];
-		} else {
-			if (!empty($GLOBALS['TSFE']->page['description'])) {
-				$og['description'] = $GLOBALS['TSFE']->page['description'];
-			} else {
-				$og['description'] = $conf['description'];
-			}
-		}
-		$og['description'] = htmlspecialchars($og['description']);
+        // Get description
+        if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'])) {
+            $og['description'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'];
+        } else {
+            if (!empty($GLOBALS['TSFE']->page['description'])) {
+                $og['description'] = $GLOBALS['TSFE']->page['description'];
+            } else {
+                $og['description'] = $conf['description'];
+            }
+        }
+        $og['description'] = htmlspecialchars($og['description']);
 
-		// Get locale
-		$localeParts = explode('.', $GLOBALS['TSFE']->tmpl->setup['config.']['locale_all']);
-		if (isset($localeParts[0])) {
-			$og['locale'] = str_replace('-', '_', $localeParts[0]);
-		}
+        // Get locale
+        $localeParts = explode('.', $GLOBALS['TSFE']->tmpl->setup['config.']['locale_all']);
+        if (isset($localeParts[0])) {
+            $og['locale'] = str_replace('-', '_', $localeParts[0]);
+        }
 
-		// Signal to manipulate og-properties before header creation
-		$this->signalSlotDispatcher->dispatch(
-			__CLASS__,
-			'beforeHeaderCreation',
-			array(&$og, $this->cObj)
-		);
+        // Signal to manipulate og-properties before header creation
+        $this->signalSlotDispatcher->dispatch(
+            __CLASS__,
+            'beforeHeaderCreation',
+            array(&$og, $this->cObj)
+        );
 
-		//add tags to html-header
-		$GLOBALS['TSFE']->additionalHeaderData[$extKey] = $this->renderHeaderLines($og);
+        //add tags to html-header
+        $GLOBALS['TSFE']->additionalHeaderData[$extKey] = $this->renderHeaderLines($og);
 
-		return $content;
-	}
+        return $content;
+    }
 
-	/**
-	 * Renders the header lines to be added from array
-	 *
-	 * @param	array		$array
-	 * @return	string
-	 */
-	protected function renderHeaderLines($array)
-	{
-		$res = array();
-		foreach ($array as $key => $value)
-		{
-			if (!empty($value))
-			{
-				// Skip empty values to prevent from empty og property
-				if (is_array($value))
-				{
-					// A op property with multiple values or child-properties
-					if (array_key_exists('0', $value))
-					{
-						// A og property that accepts more than one value
-						foreach ($value as $multiPropertyValue)
-						{
-							// Render each value to a new og property meta-tag
-							if ($key == 'image')
-							{
-								// Add image details
-								$res[] = $this->buildOgImageProperties($key, $multiPropertyValue);
-							} else
-							{
-								$res[] = $this->buildProperty($key, $multiPropertyValue);
-							}
-						}
-					} else
-					{
-						// A og property with child-properties
-						$res .= $this->renderHeaderLines($this->remapArray($key, $value));
-					}
-				} else
-				{
-					// A single og property to be rendered
-					$res[] = $this->buildProperty($key, $value);
-				}
-			}
-		}
-		return implode(chr(10), ArrayUtility::flatten($res));
-	}
+    /**
+     * Renders the header lines to be added from array
+     *
+     * @param	array		$array
+     * @return	string
+     */
+    protected function renderHeaderLines($array)
+    {
+        $res = array();
+        foreach ($array as $key => $value)
+        {
+            if (!empty($value))
+            {
+                // Skip empty values to prevent from empty og property
+                if (is_array($value))
+                {
+                    // A op property with multiple values or child-properties
+                    if (array_key_exists('0', $value))
+                    {
+                        // A og property that accepts more than one value
+                        foreach ($value as $multiPropertyValue)
+                        {
+                            // Render each value to a new og property meta-tag
+                            if ($key == 'image')
+                            {
+                                // Add image details
+                                $res[] = $this->buildOgImageProperties($key, $multiPropertyValue);
+                            } else
+                            {
+                                $res[] = $this->buildProperty($key, $multiPropertyValue);
+                            }
+                        }
+                    } else
+                    {
+                        // A og property with child-properties
+                        $res .= $this->renderHeaderLines($this->remapArray($key, $value));
+                    }
+                } else
+                {
+                    // A single og property to be rendered
+                    $res[] = $this->buildProperty($key, $value);
+                }
+            }
+        }
+        return implode(chr(10), ArrayUtility::flatten($res));
+    }
 
-	/**
-	 * Builds open graph properties for images
-	 *
-	 * @param string $key
-	 * @param mixed $value
-	 * @return array
-	 */
-	protected function buildOgImageProperties($key, $value)
-	{
-		$res = array();
+    /**
+     * Builds open graph properties for images
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return array
+     */
+    protected function buildOgImageProperties($key, $value)
+    {
+        $res = array();
 
-		if (is_object($value) && $value instanceOf FileReference)
-		{
-			/** @var FileReference $value */
-			$res[] = $this->buildProperty($key,
-				GeneralUtility::locationHeaderUrl($value->getPublicUrl()));
-			$res[] = $this->buildProperty($key . ':type', $value->getMimeType());
-			$res[] = $this->buildProperty($key . ':width',
-				$value->getProperty('width'));
-			$res[] = $this->buildProperty($key . ':height',
-				$value->getProperty('height'));
-		} else if (is_string($value))
-		{
-			$imageSize = array();
-			$parsedUrl = parse_url($value);
-			if (isset($parsedUrl['host']) && $parsedUrl['host'])
-			{
-				// Analyze image with given host
-				$res[] = $this->buildProperty($key, $value);
+        if (is_object($value) && $value instanceOf FileReference)
+        {
+            /** @var FileReference $value */
+            $res[] = $this->buildProperty($key,
+                GeneralUtility::locationHeaderUrl($value->getPublicUrl()));
+            $res[] = $this->buildProperty($key . ':type', $value->getMimeType());
+            $res[] = $this->buildProperty($key . ':width',
+                $value->getProperty('width'));
+            $res[] = $this->buildProperty($key . ':height',
+                $value->getProperty('height'));
+        } else if (is_string($value))
+        {
+            $imageSize = array();
+            $parsedUrl = parse_url($value);
+            if (isset($parsedUrl['host']) && $parsedUrl['host'])
+            {
+                // Analyze image with given host
+                $res[] = $this->buildProperty($key, $value);
 
-				if (GeneralUtility::getHostname() == $parsedUrl['host'])
-				{
-					// Get image absolute filename on own host
-					$value = GeneralUtility::getFileAbsFileName(
-						substr($parsedUrl['path'], 1) .
-						(isset($parsedUrl['query']) && $parsedUrl['query'] ? '?' . $parsedUrl['query'] : '') .
-						(isset($parsedUrl['fragment']) && $parsedUrl['fragment'] ? '#' . $parsedUrl['fragment'] : '')
-					);
-				}
+                if (GeneralUtility::getHostname() == $parsedUrl['host'])
+                {
+                    // Get image absolute filename on own host
+                    $value = GeneralUtility::getFileAbsFileName(
+                        substr($parsedUrl['path'], 1) .
+                        (isset($parsedUrl['query']) && $parsedUrl['query'] ? '?' . $parsedUrl['query'] : '') .
+                        (isset($parsedUrl['fragment']) && $parsedUrl['fragment'] ? '#' . $parsedUrl['fragment'] : '')
+                    );
+                }
 
-				if (file_exists($value))
-					$imageSize = getimagesize($value);
-			} else
-			{
-				// Analyze image with relative filename
-				$absImagePath = GeneralUtility::getFileAbsFileName($value);
-				if (file_exists($absImagePath))
-				{
-					$imageSize = getimagesize($absImagePath);
+                if (file_exists($value))
+                    $imageSize = getimagesize($value);
+            } else
+            {
+                // Analyze image with relative filename
+                $absImagePath = GeneralUtility::getFileAbsFileName($value);
+                if (file_exists($absImagePath))
+                {
+                    $imageSize = getimagesize($absImagePath);
 
-					$res[] = $this->buildProperty($key,
-						GeneralUtility::locationHeaderUrl($value));
-				}
-			}
+                    $res[] = $this->buildProperty($key,
+                        GeneralUtility::locationHeaderUrl($value));
+                }
+            }
 
-			// Add image details if available
-			if (isset($imageSize['mime']) && $imageSize['mime'])
-				$res[] = $this->buildProperty($key . ':type', $imageSize['mime']);
-			if (isset($imageSize[0]) && $imageSize[0])
-				$res[] = $this->buildProperty($key . ':width', $imageSize[0]);
-			if (isset($imageSize[1]) && $imageSize[1])
-				$res[] = $this->buildProperty($key . ':height', $imageSize[1]);
-		}
+            // Add image details if available
+            if (isset($imageSize['mime']) && $imageSize['mime'])
+                $res[] = $this->buildProperty($key . ':type', $imageSize['mime']);
+            if (isset($imageSize[0]) && $imageSize[0])
+                $res[] = $this->buildProperty($key . ':width', $imageSize[0]);
+            if (isset($imageSize[1]) && $imageSize[1])
+                $res[] = $this->buildProperty($key . ':height', $imageSize[1]);
+        }
 
-		return $res;
-	}
+        return $res;
+    }
 
-	/**
-	 * Build meta property tag
-	 *
-	 * @param   string  $key
-	 * @param   string  $value
-	 * @return  string
-	 */
-	protected function buildProperty($key, $value)
-	{
-		return '<meta property="og:' . $key . '" content="' . $value . '" />';
-	}
+    /**
+     * Build meta property tag
+     *
+     * @param   string  $key
+     * @param   string  $value
+     * @return  string
+     */
+    protected function buildProperty($key, $value)
+    {
+        return '<meta property="og:' . $key . '" content="' . $value . '" />';
+    }
 
-	/**
-	 * Remap an array: Add $prefixKey to keys of $array
-	 *
-	 * @param	string	$prefixKey
-	 * @param	array		$array
-	 * @return	array
-	 */
-	protected function remapArray($prefixKey, $array)
-	{
-		$res = array();
-		foreach ($array as $key => $value)
-			$res[$prefixKey.':'.$key] = $value;
+    /**
+     * Remap an array: Add $prefixKey to keys of $array
+     *
+     * @param	string	$prefixKey
+     * @param	array		$array
+     * @return	array
+     */
+    protected function remapArray($prefixKey, $array)
+    {
+        $res = array();
+        foreach ($array as $key => $value)
+            $res[$prefixKey.':'.$key] = $value;
 
-		return $res;
-	}
+        return $res;
+    }
 }

--- a/Classes/Service/OgRendererService.php
+++ b/Classes/Service/OgRendererService.php
@@ -2,32 +2,34 @@
 namespace Heilmann\JhOpengraphprotocol\Service;
 
 /***************************************************************
-*  Copyright notice
-*
-*  (c) 2014-2016 Jonathan Heilmann <mail@jonathan-heilmann.de>
-*  All rights reserved
-*
-*  This script is part of the TYPO3 project. The TYPO3 project is
-*  free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2 of the License, or
-*  (at your option) any later version.
-*
-*  The GNU General Public License can be found at
-*  http://www.gnu.org/copyleft/gpl.html.
-*
-*  This script is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  This copyright notice MUST APPEAR in all copies of the script!
-***************************************************************/
+ *  Copyright notice
+ *
+ *  (c) 2014-2016 Jonathan Heilmann <mail@jonathan-heilmann.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
 
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * Class OgRendererService
@@ -36,277 +38,280 @@ use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 class OgRendererService implements \TYPO3\CMS\Core\SingletonInterface
 {
 
-    /**
-     * content Object
-     *
-     * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
-     */
-    public $cObj;
+	/**
+	 * content Object
+	 *
+	 * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
+	 */
+	public $cObj;
 
-    /**
-     * SignalSlotDispatcher
-     *
-     * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
-     * @inject
-     */
-    protected $signalSlotDispatcher;
+	/**
+	 * SignalSlotDispatcher
+	 *
+	 * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
+	 * @inject
+	 */
+	protected $signalSlotDispatcher;
 
-    /**
-     * Main-function to render the Open Graph protocol content.
-     *
-     * @param	string	$content
-     * @param	array		$conf
-     * @return	string
-     */
-    public function main($content, $conf)
-    {
-        $extKey = 'tx_jhopengraphprotocol';
-        $content = '';
-        $og = array();
+	/**
+	 * Main-function to render the Open Graph protocol content.
+	 *
+	 * @param	string	$content
+	 * @param	array		$conf
+	 * @return	string
+	 */
+	public function main($content, $conf)
+	{
+		$extKey = 'tx_jhopengraphprotocol';
+		$content = '';
+		$og = array();
 
-        if ($this->signalSlotDispatcher == null) {
-            /* @var \TYPO3\CMS\Extbase\Object\ObjectManager */
-            $objectManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-            $this->signalSlotDispatcher = $objectManager->get('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
-        }
+		if ($this->signalSlotDispatcher == null) {
+			/* @var \TYPO3\CMS\Extbase\Object\ObjectManager */
+			$objectManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
+			$this->signalSlotDispatcher = $objectManager->get('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
+		}
 
-        // 2013-04-22	kraftb@webconsulting.at
-        // Check if the tt_news "displaySingle" method has been called before
-        if (class_exists('tx_jhopengraphttnews_displaySingleHook')) {
-            $hookObject = GeneralUtility::makeInstance('tx_jhopengraphttnews_displaySingleHook');
-            if ($hookObject->singleViewDisplayed())
-                return $content;
-        }
-        if (class_exists(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class)) {
-            $hookObject = GeneralUtility::makeInstance(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class);
-            if ($hookObject->singleViewDisplayed())
-                return $content;
-        }
+		// 2013-04-22	kraftb@webconsulting.at
+		// Check if the tt_news "displaySingle" method has been called before
+		if (class_exists('tx_jhopengraphttnews_displaySingleHook')) {
+			$hookObject = GeneralUtility::makeInstance('tx_jhopengraphttnews_displaySingleHook');
+			if ($hookObject->singleViewDisplayed())
+				return $content;
+		}
+		if (class_exists(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class)) {
+			$hookObject = GeneralUtility::makeInstance(\Heilmann\JhOpengraphTtnews\Hooks\DisplaySingle::class);
+			if ($hookObject->singleViewDisplayed())
+				return $content;
+		}
 
-        //if there has been no return, get og properties and render output
+		//if there has been no return, get og properties and render output
 
-        // Get title
-        if (!empty($this->cObj->data['tx_jhopengraphprotocol_ogtitle'])) {
-            $og['title'] = $this->cObj->data['tx_jhopengraphprotocol_ogtitle'];
-        } else {
-            $og['title'] = $GLOBALS['TSFE']->page['title'];
-        }
-        $og['title'] = htmlspecialchars($og['title']);
+		// Get title
+		if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'])) {
+			$og['title'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtitle'];
+		} else {
+			$og['title'] = $GLOBALS['TSFE']->page['title'];
+		}
+		$og['title'] = htmlspecialchars($og['title']);
 
-        // Get type
-        if (!empty($this->cObj->data['tx_jhopengraphprotocol_ogtype'])) {
-            $og['type'] = $this->cObj->data['tx_jhopengraphprotocol_ogtype'];
-        } else {
-            $og['type'] = $conf['type'];
-        }
-        $og['type'] = htmlspecialchars($og['type']);
+		// Get type
+		if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'])) {
+			$og['type'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogtype'];
+		} else {
+			$og['type'] = $conf['type'];
+		}
+		$og['type'] = htmlspecialchars($og['type']);
 
-        // Get image
-        /** @var \TYPO3\CMS\Core\Resource\FileRepository $fileRepository */
-        $fileRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
-        $fileObjects = $fileRepository->findByRelation('pages', 'tx_jhopengraphprotocol_ogfalimages', $GLOBALS['TSFE']->id);
-        if (count($fileObjects)) {
-            foreach ($fileObjects as $key => $fileObject) {
-                /** @var FileReference $fileObject */
-                $og['image'][] = $fileObject;
-            }
-        } else {
-            // check if an image is given in page --> media, if not use default image
-            $fileObjects = $fileRepository->findByRelation('pages', 'media', $GLOBALS['TSFE']->id);
-            if (count($fileObjects)) {
-                foreach ($fileObjects as $key => $fileObject) {
-                    /** @var FileReference $fileObject */
-                    $og['image'][] = $fileObject;
-                }
-            } else {
-                $imageFileName = $GLOBALS['TSFE']->tmpl->getFileName($conf['image']);
-                if (!empty($imageFileName)) {
-                    $og['image'][] = $imageFileName;
-                }
-            }
-        }
-        
-        // Get url
-        $og['url'] = htmlentities(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
+		$fileRelationPid = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ?: $GLOBALS['TSFE']->id;
+		$fileRelationTable = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ? 'pages_language_overlay' : 'pages';
 
-        // Get site_name
-        if (!empty($conf['sitename'])) {
-            $og['site_name'] = $conf['sitename'];
-        } else {
-            $og['site_name'] = $GLOBALS['TSFE']->tmpl->setup['sitetitle'];
-        }
-        $og['site_name'] = htmlspecialchars($og['site_name']);
+		// Get image
+		/** @var \TYPO3\CMS\Core\Resource\FileRepository $fileRepository */
+		$fileRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
+		$fileObjects = $fileRepository->findByRelation($fileRelationTable, 'tx_jhopengraphprotocol_ogfalimages', $fileRelationPid);
+		if (count($fileObjects)) {
+			foreach ($fileObjects as $key => $fileObject) {
+				/** @var FileReference $fileObject */
+				$og['image'][] = $fileObject;
+			}
+		} else {
+			// check if an image is given in page --> media, if not use default image
+			$fileObjects = $fileRepository->findByRelation($fileRelationTable, 'media', $fileRelationPid);
+			if (count($fileObjects)) {
+				foreach ($fileObjects as $key => $fileObject) {
+					/** @var FileReference $fileObject */
+					$og['image'][] = $fileObject;
+				}
+			} else {
+				$imageFileName = $GLOBALS['TSFE']->tmpl->getFileName($conf['image']);
+				if (!empty($imageFileName)) {
+					$og['image'][] = $imageFileName;
+				}
+			}
+		}
 
-        // Get description
-        if (!empty($this->cObj->data['tx_jhopengraphprotocol_ogdescription'])) {
-            $og['description'] = $this->cObj->data['tx_jhopengraphprotocol_ogdescription'];
-        } else {
-            if (!empty($GLOBALS['TSFE']->page['description'])) {
-                $og['description'] = $GLOBALS['TSFE']->page['description'];
-            } else {
-                $og['description'] = $conf['description'];
-            }
-        }
-        $og['description'] = htmlspecialchars($og['description']);
+		// Get url
+		$og['url'] = htmlentities(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
 
-        // Get locale
-        $localeParts = explode('.', $GLOBALS['TSFE']->tmpl->setup['config.']['locale_all']);
-        if (isset($localeParts[0])) {
-            $og['locale'] = str_replace('-', '_', $localeParts[0]);
-        }
+		// Get site_name
+		if (!empty($conf['sitename'])) {
+			$og['site_name'] = $conf['sitename'];
+		} else {
+			$og['site_name'] = $GLOBALS['TSFE']->tmpl->setup['sitetitle'];
+		}
+		$og['site_name'] = htmlspecialchars($og['site_name']);
 
-        // Signal to manipulate og-properties before header creation
-        $this->signalSlotDispatcher->dispatch(
-            __CLASS__,
-            'beforeHeaderCreation',
-            array(&$og, $this->cObj)
-        );
+		// Get description
+		if (!empty($GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'])) {
+			$og['description'] = $GLOBALS['TSFE']->page['tx_jhopengraphprotocol_ogdescription'];
+		} else {
+			if (!empty($GLOBALS['TSFE']->page['description'])) {
+				$og['description'] = $GLOBALS['TSFE']->page['description'];
+			} else {
+				$og['description'] = $conf['description'];
+			}
+		}
+		$og['description'] = htmlspecialchars($og['description']);
 
-        //add tags to html-header
-        $GLOBALS['TSFE']->additionalHeaderData[$extKey] = $this->renderHeaderLines($og);
+		// Get locale
+		$localeParts = explode('.', $GLOBALS['TSFE']->tmpl->setup['config.']['locale_all']);
+		if (isset($localeParts[0])) {
+			$og['locale'] = str_replace('-', '_', $localeParts[0]);
+		}
 
-        return $content;
-    }
+		// Signal to manipulate og-properties before header creation
+		$this->signalSlotDispatcher->dispatch(
+			__CLASS__,
+			'beforeHeaderCreation',
+			array(&$og, $this->cObj)
+		);
 
-    /**
-     * Renders the header lines to be added from array
-     *
-     * @param	array		$array
-     * @return	string
-     */
-    protected function renderHeaderLines($array)
-    {
-        $res = array();
-        foreach ($array as $key => $value)
-        {
-            if (!empty($value))
-            {
-                // Skip empty values to prevent from empty og property
-                if (is_array($value))
-                {
-                    // A op property with multiple values or child-properties
-                    if (array_key_exists('0', $value))
-                    {
-                        // A og property that accepts more than one value
-                        foreach ($value as $multiPropertyValue)
-                        {
-                            // Render each value to a new og property meta-tag
-                            if ($key == 'image')
-                            {
-                                // Add image details
-                                $res[] = $this->buildOgImageProperties($key, $multiPropertyValue);
-                            } else
-                            {
-                                $res[] = $this->buildProperty($key, $multiPropertyValue);
-                            }
-                        }
-                    } else
-                    {
-                        // A og property with child-properties
-                        $res .= $this->renderHeaderLines($this->remapArray($key, $value));
-                    }
-                } else
-                {
-                    // A single og property to be rendered
-                    $res[] = $this->buildProperty($key, $value);
-                }
-            }
-        }
-        return implode(chr(10), ArrayUtility::flatten($res));
-    }
+		//add tags to html-header
+		$GLOBALS['TSFE']->additionalHeaderData[$extKey] = $this->renderHeaderLines($og);
 
-    /**
-     * Builds open graph properties for images
-     *
-     * @param string $key
-     * @param mixed $value
-     * @return array
-     */
-    protected function buildOgImageProperties($key, $value)
-    {
-        $res = array();
+		return $content;
+	}
 
-        if (is_object($value) && $value instanceOf FileReference)
-        {
-            /** @var FileReference $value */
-            $res[] = $this->buildProperty($key,
-                GeneralUtility::locationHeaderUrl($value->getPublicUrl()));
-            $res[] = $this->buildProperty($key . ':type', $value->getMimeType());
-            $res[] = $this->buildProperty($key . ':width',
-                $value->getProperty('width'));
-            $res[] = $this->buildProperty($key . ':height',
-                $value->getProperty('height'));
-        } else if (is_string($value))
-        {
-            $imageSize = array();
-            $parsedUrl = parse_url($value);
-            if (isset($parsedUrl['host']) && $parsedUrl['host'])
-            {
-                // Analyze image with given host
-                $res[] = $this->buildProperty($key, $value);
+	/**
+	 * Renders the header lines to be added from array
+	 *
+	 * @param	array		$array
+	 * @return	string
+	 */
+	protected function renderHeaderLines($array)
+	{
+		$res = array();
+		foreach ($array as $key => $value)
+		{
+			if (!empty($value))
+			{
+				// Skip empty values to prevent from empty og property
+				if (is_array($value))
+				{
+					// A op property with multiple values or child-properties
+					if (array_key_exists('0', $value))
+					{
+						// A og property that accepts more than one value
+						foreach ($value as $multiPropertyValue)
+						{
+							// Render each value to a new og property meta-tag
+							if ($key == 'image')
+							{
+								// Add image details
+								$res[] = $this->buildOgImageProperties($key, $multiPropertyValue);
+							} else
+							{
+								$res[] = $this->buildProperty($key, $multiPropertyValue);
+							}
+						}
+					} else
+					{
+						// A og property with child-properties
+						$res .= $this->renderHeaderLines($this->remapArray($key, $value));
+					}
+				} else
+				{
+					// A single og property to be rendered
+					$res[] = $this->buildProperty($key, $value);
+				}
+			}
+		}
+		return implode(chr(10), ArrayUtility::flatten($res));
+	}
 
-                if (GeneralUtility::getHostname() == $parsedUrl['host'])
-                {
-                    // Get image absolute filename on own host
-                    $value = GeneralUtility::getFileAbsFileName(
-                        substr($parsedUrl['path'], 1) .
-                        (isset($parsedUrl['query']) && $parsedUrl['query'] ? '?' . $parsedUrl['query'] : '') .
-                        (isset($parsedUrl['fragment']) && $parsedUrl['fragment'] ? '#' . $parsedUrl['fragment'] : '')
-                    );
-                }
+	/**
+	 * Builds open graph properties for images
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @return array
+	 */
+	protected function buildOgImageProperties($key, $value)
+	{
+		$res = array();
 
-                if (file_exists($value))
-                    $imageSize = getimagesize($value);
-            } else
-            {
-                // Analyze image with relative filename
-                $absImagePath = GeneralUtility::getFileAbsFileName($value);
-                if (file_exists($absImagePath))
-                {
-                    $imageSize = getimagesize($absImagePath);
+		if (is_object($value) && $value instanceOf FileReference)
+		{
+			/** @var FileReference $value */
+			$res[] = $this->buildProperty($key,
+				GeneralUtility::locationHeaderUrl($value->getPublicUrl()));
+			$res[] = $this->buildProperty($key . ':type', $value->getMimeType());
+			$res[] = $this->buildProperty($key . ':width',
+				$value->getProperty('width'));
+			$res[] = $this->buildProperty($key . ':height',
+				$value->getProperty('height'));
+		} else if (is_string($value))
+		{
+			$imageSize = array();
+			$parsedUrl = parse_url($value);
+			if (isset($parsedUrl['host']) && $parsedUrl['host'])
+			{
+				// Analyze image with given host
+				$res[] = $this->buildProperty($key, $value);
 
-                    $res[] = $this->buildProperty($key,
-                        GeneralUtility::locationHeaderUrl($value));
-                }
-            }
+				if (GeneralUtility::getHostname() == $parsedUrl['host'])
+				{
+					// Get image absolute filename on own host
+					$value = GeneralUtility::getFileAbsFileName(
+						substr($parsedUrl['path'], 1) .
+						(isset($parsedUrl['query']) && $parsedUrl['query'] ? '?' . $parsedUrl['query'] : '') .
+						(isset($parsedUrl['fragment']) && $parsedUrl['fragment'] ? '#' . $parsedUrl['fragment'] : '')
+					);
+				}
 
-            // Add image details if available
-            if (isset($imageSize['mime']) && $imageSize['mime'])
-                $res[] = $this->buildProperty($key . ':type', $imageSize['mime']);
-            if (isset($imageSize[0]) && $imageSize[0])
-                $res[] = $this->buildProperty($key . ':width', $imageSize[0]);
-            if (isset($imageSize[1]) && $imageSize[1])
-                $res[] = $this->buildProperty($key . ':height', $imageSize[1]);
-        }
+				if (file_exists($value))
+					$imageSize = getimagesize($value);
+			} else
+			{
+				// Analyze image with relative filename
+				$absImagePath = GeneralUtility::getFileAbsFileName($value);
+				if (file_exists($absImagePath))
+				{
+					$imageSize = getimagesize($absImagePath);
 
-        return $res;
-    }
+					$res[] = $this->buildProperty($key,
+						GeneralUtility::locationHeaderUrl($value));
+				}
+			}
 
-    /**
-     * Build meta property tag
-     *
-     * @param   string  $key
-     * @param   string  $value
-     * @return  string
-     */
-    protected function buildProperty($key, $value)
-    {
-        return '<meta property="og:' . $key . '" content="' . $value . '" />';
-    }
+			// Add image details if available
+			if (isset($imageSize['mime']) && $imageSize['mime'])
+				$res[] = $this->buildProperty($key . ':type', $imageSize['mime']);
+			if (isset($imageSize[0]) && $imageSize[0])
+				$res[] = $this->buildProperty($key . ':width', $imageSize[0]);
+			if (isset($imageSize[1]) && $imageSize[1])
+				$res[] = $this->buildProperty($key . ':height', $imageSize[1]);
+		}
 
-    /**
-     * Remap an array: Add $prefixKey to keys of $array
-     *
-     * @param	string	$prefixKey
-     * @param	array		$array
-     * @return	array
-     */
-    protected function remapArray($prefixKey, $array)
-    {
-        $res = array();
-        foreach ($array as $key => $value)
-            $res[$prefixKey.':'.$key] = $value;
+		return $res;
+	}
 
-        return $res;
-    }
+	/**
+	 * Build meta property tag
+	 *
+	 * @param   string  $key
+	 * @param   string  $value
+	 * @return  string
+	 */
+	protected function buildProperty($key, $value)
+	{
+		return '<meta property="og:' . $key . '" content="' . $value . '" />';
+	}
+
+	/**
+	 * Remap an array: Add $prefixKey to keys of $array
+	 *
+	 * @param	string	$prefixKey
+	 * @param	array		$array
+	 * @return	array
+	 */
+	protected function remapArray($prefixKey, $array)
+	{
+		$res = array();
+		foreach ($array as $key => $value)
+			$res[$prefixKey.':'.$key] = $value;
+
+		return $res;
+	}
 }

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -72,8 +72,9 @@ $tempColumns = array(
         'exclude' => 1,
         'label' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang.xml:pages.tx_jhopengraphprotocol_ogdescription',
         'config' => array(
-            'type' => 'input',
+            'type' => 'text',
             'size' => '30',
+            'rows' => '3',
             'max' => '300',
         )
     ),


### PR DESCRIPTION
Supersedes PR #38 for deployment and testing and will be merged in master as soon as it is stable.

> This fixes the page overlay bug #23 I guess.
The changes to composer.json can be ignored. I had to make them to temporarily integrate my fork into our project.

> The problem with the page overlay was, that $this->cObj->data only contains the information of the current database record, but without being overlayed. The $GLOBALS['TSFE']->page is the way to go for all fields.

> Additionally fetching the file relations have to be done from pages_language_overlay if not in default language. Therefore I introduced two new variables for fetching file relations based on the curreent sys_language_uid.

> This is only tested on TYPO3 7.6.9 but I think it should work on every other supported version.