### PR TITLE
Fixed issue #48 

### DIFF
--- a/Classes/Service/OgRendererService.php
+++ b/Classes/Service/OgRendererService.php
@@ -140,7 +140,18 @@ class OgRendererService implements \TYPO3\CMS\Core\SingletonInterface
             $og['image'] = $fileObjects;
 
         // Get url
-        $og['url'] = htmlentities(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
+        $og['url'] = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
+        $cObject = GeneralUtility::makeInstance('tslib_cObj');
+        $configurations['additionalParams'] = "&L=".(int)GeneralUtility::_GP('L');
+        $configurations['returnLast'] = 'url'; // get it as URL
+        $configurations['parameter'] =  $GLOBALS['TSFE']->id;
+        $og['url'] .= htmlspecialchars($cObject->typolink(NULL, $configurations));
+
+
+
+
+
+
 
         // Get site_name
         $og['site_name'] = htmlspecialchars(!empty($conf['sitename']) ?

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,7 +3,12 @@ if (!defined('TYPO3_MODE'))
     die('Access denied.');
 
 // Get extension configuration
-$extConf = \TYPO3\CMS\Core\Utility\GeneralUtility::removeDotsFromTS(unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]));
+if( isset( $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY])) {
+    $extConf = \TYPO3\CMS\Core\Utility\GeneralUtility::removeDotsFromTS(unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]));
+} else {
+    $extConf = array();
+}
+
 
 // Create array with columns
 $tempColumns = array(


### PR DESCRIPTION
The following error message was thrown if extension configuration was empty. For example, during first time install.

Argument 1 passed to TYPO3\CMS\Core\Utility\GeneralUtility::removeDotsFromTS() must be of the type array, boolean given, called in typo3conf/ext/jh_opengraphprotocol/ext_tables.php on line 6


Another fix - make og:url return properly formatted URL if RealURL  installed.

