### PR TITLE
Bugfix: Change composer.json typo3/cms requirement to OR instead of AND

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "version": "1.3.0-dev",
   "require": {
-    "typo3/cms": "~6.2,~7.6"
+    "typo3/cms": "~6.2||~7.6"
   },
   "replace": {
     "jh_opengraphprotocol": "self.version",


### PR DESCRIPTION
It was not possible to load the extension via composer, since the version requirement could never be met. A backport into 1.2.5 would be nice too.