### PR TITLE
change USER to USER_INT to prevent caching

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,7 +1,7 @@
 config.htmlTag_setParams := appendString( xmlns:og="http://ogp.me/ns#")
 
 includeLibs.tx_jhopengraphprotocol = EXT:jh_opengraphprotocol/Classes/Service/OgRendererService.php
-temp.tx_jhopengraphprotocol = USER
+temp.tx_jhopengraphprotocol = USER_INT
 temp.tx_jhopengraphprotocol {
     userFunc = Heilmann\JhOpengraphprotocol\Service\OgRendererService->main
     type = {$plugin.tx_jhopengraphprotocol.type}


### PR DESCRIPTION
Hi there,

we had a situation where an extension would render a specific product based on the (real) URL, and set the og-tags accordingly in the `beforeHeaderCreation` slot. This was working fine until you added another querystring parameter that was not captured by the cHash; then the og-tags from the last "valid" URL were taken. We solved this by overriding `page.669` with a `USER_INT`, and thought it would be a good idea to make this the default behaviour.

Anyway if you think this is not appropriate performance-wise, I might open an issue instead -- maybe we could find a more convenient way to make this configurable. `:-)`

All the best
Sebastian